### PR TITLE
add in extra field to StripeError to capture all other fields

### DIFF
--- a/client/error_test.go
+++ b/client/error_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	. "github.com/getbread/stripe-go"
+	"github.com/getbread/stripe-go/currency"
+	"github.com/getbread/stripe-go/utils"
 )
 
 func TestErrors(t *testing.T) {
@@ -25,4 +27,49 @@ func TestErrors(t *testing.T) {
 	if stripeErr.HTTPStatusCode != 401 {
 		t.Errorf("HTTPStatusCode %q does not match expected value of \"401\"", stripeErr.HTTPStatusCode)
 	}
+}
+
+func TestErrorsExtra(t *testing.T) {
+	apiKey := utils.GetTestKey()
+
+	c := &API{}
+	c.Init(apiKey, nil)
+
+	cardParams := &CardParams{
+		CVC:    "888",
+		Month:  "05",
+		Year:   "2019",
+		Number: "4000000000000341",
+	}
+	token, err := c.Tokens.New(&TokenParams{
+		Card: cardParams,
+	})
+
+	chargeParams := &ChargeParams{
+		Amount:   10000,
+		Currency: currency.USD,
+	}
+	chargeParams.SetSource(token.ID)
+
+	_, err = c.Charges.New(chargeParams)
+
+	if err == nil {
+		t.Errorf("Expected an error")
+	}
+
+	stripeErr := err.(*Error)
+
+	if len(stripeErr.Extra) == 0 {
+		t.Error("Expecting `Extra` field to be filled.")
+	}
+
+	chargeId, ok := stripeErr.Extra["charge"]
+	if !ok {
+		t.Error("Expecting `charge` key in `Extra` field to be present.")
+	}
+
+	if chargeId == "" {
+		t.Error("`charge` field should not be empty.")
+	}
+
 }

--- a/error.go
+++ b/error.go
@@ -34,11 +34,12 @@ const (
 // Error is the response returned when a call is unsuccessful.
 // For more details see  https://stripe.com/docs/api#errors.
 type Error struct {
-	Type           ErrorType `json:"type"`
-	Msg            string    `json:"message"`
-	Code           ErrorCode `json:"code,omitempty"`
-	Param          string    `json:"param,omitempty"`
-	HTTPStatusCode int       `json:"-"`
+	Type           ErrorType              `json:"type"`
+	Msg            string                 `json:"message"`
+	Code           ErrorCode              `json:"code,omitempty"`
+	Param          string                 `json:"param,omitempty"`
+	Extra          map[string]interface{} `json:"extra,omitempty"`
+	HTTPStatusCode int                    `json:"-"`
 }
 
 // Error serializes the Error object and prints the JSON string.

--- a/stripe.go
+++ b/stripe.go
@@ -245,14 +245,20 @@ func (s *BackendConfiguration) Do(req *http.Request, v interface{}) error {
 				Msg:            root["message"].(string),
 				HTTPStatusCode: res.StatusCode,
 			}
+			delete(root, "type")
+			delete(root, "message")
 
 			if code, found := root["code"]; found {
 				err.Code = ErrorCode(code.(string))
+				delete(root, "code")
 			}
 
 			if param, found := root["param"]; found {
 				err.Param = param.(string)
+				delete(root, "param")
 			}
+
+			err.Extra = root
 
 			if LogLevel > 0 {
 				log.Printf("Error encountered from Stripe: %v\n", err)


### PR DESCRIPTION
Ensures stripe error captures all fields returned by the api.