### PR TITLE
proper reversal param

### DIFF
--- a/refund/client.go
+++ b/refund/client.go
@@ -39,7 +39,7 @@ func (c Client) New(params *stripe.RefundParams) (*stripe.Refund, error) {
 	}
 
 	if params.Transfer {
-		body.Add("refund_transfer", strconv.FormatBool(params.Transfer))
+		body.Add("reverse_transfer", strconv.FormatBool(params.Transfer))
 	}
 
 	if len(params.Reason) > 0 {


### PR DESCRIPTION
The proper parameter is `reverse_transfer`.

Reference: https://stripe.com/docs/api/go#create_refund

:shipit: 