### PR TITLE
balance_transaction comes back as a string ID, not a JSON object.

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -61,7 +61,7 @@ type Charge struct {
 	Refunded       bool              `json:"refunded"`
 	Refunds        *RefundList       `json:"refunds"`
 	AmountRefunded uint64            `json:"amount_refunded"`
-	Tx             *Transaction      `json:"balance_transaction"`
+	Tx             string            `json:"balance_transaction"`
 	Destination    *Account          `json:"destination"`
 	Transfer       *Transfer         `json:"transfer"`
 	Customer       *Customer         `json:"customer"`

--- a/refund.go
+++ b/refund.go
@@ -30,7 +30,7 @@ type Refund struct {
 	Amount   uint64            `json:"amount"`
 	Created  int64             `json:"created"`
 	Currency Currency          `json:"currency"`
-	Tx       *Transaction      `json:"balance_transaction"`
+	Tx       string            `json:"balance_transaction"`
 	Charge   string            `json:"charge"`
 	Meta     map[string]string `json:"metadata"`
 	Reason   RefundReason      `json:"reason"`


### PR DESCRIPTION
Stripe's Go API expects the `charge` JSON object's `balance_transaction` to be a JSON object, but instead it is a string ID of that object.